### PR TITLE
Add pytest tests for googlebooks utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .env
 
 /content/chatconversations
+__pycache__/

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,8 @@ verify_ssl = true
 
 [dev-packages]
 
+pytest = "*"
+
 [packages]
 
 [requires]

--- a/python/googlebooks.py
+++ b/python/googlebooks.py
@@ -83,7 +83,11 @@ def format_author_name(name):
 def normalize_authors(authors):
     if len(authors) == 1 and ":" in authors[0]:  # Check for single string with colons
         # Split by colon and clean up extra spaces or colons
-        return [author.strip().strip(":") for author in authors[0].split(":")]
+        return [
+            author.strip().strip(":")
+            for author in authors[0].split(":")
+            if author.strip().strip(":")
+        ]
     return authors  # Return as is if already a clean list
 
 # Create a markdown file

--- a/tests/test_googlebooks_utils.py
+++ b/tests/test_googlebooks_utils.py
@@ -1,0 +1,37 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def load_googlebooks():
+    path = Path(__file__).resolve().parents[1] / "python" / "googlebooks.py"
+    spec = importlib.util.spec_from_file_location("googlebooks", path)
+    module = importlib.util.module_from_spec(spec)
+    # Stub external dependencies
+    sys.modules.setdefault("requests", types.ModuleType("requests"))
+    slugify_mod = types.ModuleType("slugify")
+    slugify_mod.slugify = lambda x: x
+    sys.modules.setdefault("slugify", slugify_mod)
+    sys.modules.setdefault("yaml", types.ModuleType("yaml"))
+    spec.loader.exec_module(module)
+    return module
+
+googlebooks = load_googlebooks()
+
+
+def test_format_author_name_comma():
+    assert googlebooks.format_author_name("Doe, John") == "John Doe"
+
+
+def test_format_author_name_single():
+    assert googlebooks.format_author_name("Plato") == "Plato"
+
+
+def test_normalize_authors_colon_string():
+    result = googlebooks.normalize_authors(["Smith, John:Brown, Bob:"])
+    assert result == ["Smith, John", "Brown, Bob"]
+
+
+def test_normalize_authors_simple_list():
+    assert googlebooks.normalize_authors(["Alice"]) == ["Alice"]


### PR DESCRIPTION
## Summary
- add unit tests for googlebooks utility functions
- ignore `__pycache__`
- support tests by adding pytest dependency in `Pipfile`
- filter empty strings in `normalize_authors`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68833dbff284832aa712bfb69e40273f