### PR TITLE
Fix header argument in Kindle script

### DIFF
--- a/python/kindle_get_description_book.py
+++ b/python/kindle_get_description_book.py
@@ -25,7 +25,7 @@ headers = {
 
 for book in books:
     link = "https://www.amazon.com/dp/" + book[0]
-    page = requests.get(link, headers)
+    page = requests.get(link, headers=headers)
     soup = BeautifulSoup(page.content, 'html.parser')
     print(soup.prettify)
     #description = soup.find('div', id='iframeContent')


### PR DESCRIPTION
## Summary
- fix incorrect parameter usage in `kindle_get_description_book.py`

## Testing
- `python -m py_compile python/kindle_get_description_book.py`


------
https://chatgpt.com/codex/tasks/task_e_68833c7bb73c832aaa6d4ebe9aa5cb9e