### PR TITLE
Fix typo in git branch post

### DIFF
--- a/content/posts/git-create-new-branch.md
+++ b/content/posts/git-create-new-branch.md
@@ -28,6 +28,6 @@ Imagine you fixed the issue and committed it to the "issue40" branch by
 $ git commit -a -m "Fixed a bug [issue 40]"
 ```
 
-You are now ready to merge the issue40 branch into the main branch. You can eitehr do this locally, or do it on Github.
+You are now ready to merge the issue40 branch into the main branch. You can either do this locally, or do it on Github.
 
 


### PR DESCRIPTION
## Summary
- fix a typo in the Git new branch instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68833da5e75c832a9c6c2931b91bf219